### PR TITLE
Add response delay and stock truncation

### DIFF
--- a/server.go
+++ b/server.go
@@ -84,6 +84,12 @@ func generateQuote(conn net.Conn) {
 	// use request to generate values for response
 	resp := makeResp(req)
 
+	// Delay for 1->4s before sending back the quote.
+	// Delay periods have uniform probability.
+	delayPeriod := time.Duration(rand.Intn(4) + 1)
+	respDelayTimer := time.NewTimer(time.Second * delayPeriod)
+	<-respDelayTimer.C
+
 	// Send back the quote
 	conn.Write([]byte(resp.ToCSVString()))
 

--- a/server.go
+++ b/server.go
@@ -111,6 +111,14 @@ func parseReq(buff []byte) (quoteRequest, error) {
 }
 
 func makeResp(req quoteRequest) quoteResponse {
+	// Only use the first 3 char of a stock
+	var truncatedStock string
+	if stockLen := len(req.stock); stockLen < 3 {
+		truncatedStock = req.stock[:stockLen]
+	} else {
+		truncatedStock = req.stock[:3]
+	}
+
 	// Send back current server time
 	nowUnix := time.Now().Unix()
 
@@ -123,7 +131,7 @@ func makeResp(req quoteRequest) quoteResponse {
 
 	return quoteResponse{
 		quote:     1000 * rand.Float32(),
-		stock:     req.stock,
+		stock:     strings.ToUpper(truncatedStock),
 		userID:    req.userID,
 		timestamp: nowUnix,
 		cyrptokey: cryptokey,


### PR DESCRIPTION
Actual quoteserver will delay 1->4sec before responding. I guessed at a uniform distribution for delays.

Also discovered that the server will truncate stock names to 3 char and transform them to uppercase.