### PR TITLE
Set const price for all stocks & set response delay range

### DIFF
--- a/server.go
+++ b/server.go
@@ -25,7 +25,7 @@ var (
 	// parsed command line args
 	delayRange  = kingpin.Flag("delay-range", "Upper limit of random delay added to response").Default("3").Short('r').Int()
 	delayOffset = kingpin.Flag("delay-offset", "Constant delay for all responses").Default("0").Short('o').Uint()
-	fixedPrice  = kingpin.Flag("fixed-price", "Constant price for all stocks").Default("0.00").PlaceHolder("314.15").Short('p').Float32()
+	fixedPrice  = kingpin.Flag("fixed-price", "Constant price for all stocks. No fixed price when omitted.").Default("0.00").PlaceHolder("314.15").Short('p').Float32()
 )
 
 type quoteRequest struct {


### PR DESCRIPTION
Finer control over the quoteserver responses. Fixed prices are particularly useful for debugging buy/sell transactions.

```
$ go run server.go --help
usage: server [<flags>]

Flags:
      --help                Show context-sensitive help (also try --help-long and
                            --help-man).
  -r, --delay-range=3       Upper limit of random delay added to response
  -o, --delay-offset=0      Constant delay for all responses
  -p, --fixed-price=314.15  Constant price for all stocks. No fixed price when omitted.
```

Default behavior (no flags) is a 0->3s delay, random prices. `server.go -r 0` sends back quotes immediately. `server.go -r 2 -o 3 -p 100` sends back quotes with a delay 2->5s always at $100